### PR TITLE
Update jquery.copy-to-clipboard.js

### DIFF
--- a/jquery.copy-to-clipboard.js
+++ b/jquery.copy-to-clipboard.js
@@ -20,7 +20,7 @@ $.fn.CopyToClipboard = function() {
 function CopyToClipboard( val ){
     var hiddenClipboard = $('#_hiddenClipboard_');
     if(!hiddenClipboard.length){
-        $('body').append('<textarea style="position:absolute;top: -9999px;" id="_hiddenClipboard_"></textarea>');
+        $('body').append('<textarea readonly style="position:absolute;top: -9999px;" id="_hiddenClipboard_"></textarea>');
         hiddenClipboard = $('#_hiddenClipboard_');
     }
     hiddenClipboard.html(val);


### PR DESCRIPTION
Copying in Safari on iOS devices is accompanied by opening the keyboard. Adding a readonly attribute for the textarea element fixes this bug